### PR TITLE
Add Markdown support for Assist messages

### DIFF
--- a/Sources/App/Assist/AssistView.swift
+++ b/Sources/App/Assist/AssistView.swift
@@ -112,7 +112,7 @@ struct AssistView: View {
                 AssistTypingIndicator()
                     .padding(.vertical, Spaces.half)
             } else {
-                Text(item.content)
+                Text(item.attributedContent)
             }
         }
         .padding(8)

--- a/Sources/Extensions/Watch/Assist/Views/ChatBubbleView.swift
+++ b/Sources/Extensions/Watch/Assist/Views/ChatBubbleView.swift
@@ -10,7 +10,7 @@ struct ChatBubbleView: View {
                 AssistTypingIndicator()
                     .padding(.vertical, Spaces.half)
             } else {
-                Text(item.content)
+                Text(item.attributedContent)
             }
         }
         .padding(4)

--- a/Sources/Shared/Assist/AssistChatItem.swift
+++ b/Sources/Shared/Assist/AssistChatItem.swift
@@ -19,3 +19,8 @@ public struct AssistChatItem: Equatable {
         case info
     }
 }
+extension AssistChatItem {
+    public var attributedContent: AttributedString {
+        (try? AttributedString(markdown: content)) ?? AttributedString(content)
+    }
+}


### PR DESCRIPTION
## Summary
- render Assist chat messages as Markdown
- expose a computed property on `AssistChatItem` returning `AttributedString`

## Testing
- `bundle exec fastlane test` *(fails: rbenv: version `3.1.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862c6ca80b08327a1e584f30b3222bd